### PR TITLE
Network/win 96 base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ Temporary Items
 ## User settings
 xcuserdata/
 
+## API Keys
+APIKeys.swift
+
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -76,6 +76,7 @@ excluded:
   - Projects/App/Project.swift
   - Projects/Utils/Project.swift
   - Projects/WineyKit/Project.swift
+    - Projects/WineyNetwork/Project.swift
   - Derived
   - template
   - .tuist-bin

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -10,6 +10,15 @@ import ProjectDescriptionHelpers
 
 
 let infoPlist: [String: InfoPlist.Value] = [
+  "NSAppTransportSecurity": [
+    "NSAllowsArbitraryLoads": true,
+    "NSExceptionDomains": [
+      "example.com": [
+        "NSExceptionAllowsInsecureHTTPLoads": true,
+        "NSIncludesSubdomains": true
+      ]
+    ]
+  ],
   "CFBundleShortVersionString": "1.0",
   "CFBundleVersion": "1",
   "CFBundleDevelopmentRegion": "ko_KR",
@@ -18,38 +27,44 @@ let infoPlist: [String: InfoPlist.Value] = [
   "UIAppFonts": [
     "Item 0": "Pretendard-Medium.otf",
     "Item 1": "Pretendard-Bold.otf"
+  ],
+  "LSApplicationQueriesSchemes": [
+    "kakaokompassauth",
+    "kakaolink"
   ]
 ]
 
 let appTargets: [Target] = [
-    .init(name: "Winey",
-          platform: .iOS,
-          product: .app,
-          bundleId: "com.adultOfNineteen.app",
-          deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
-          infoPlist: .extendingDefault(with: infoPlist),
-          sources: ["Sources/**"],
-          resources: ["Resources/**"],
-          scripts: [
-            .pre(
-              script: """
+  .init(name: "Winey",
+        platform: .iOS,
+        product: .app,
+        bundleId: "com.adultOfNineteen.app",
+        deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
+        infoPlist: .extendingDefault(with: infoPlist),
+        sources: ["Sources/**"],
+        resources: ["Resources/**"],
+        scripts: [
+          .pre(
+            script: """
               ROOT_DIR=\(ProcessInfo.processInfo.environment["TUIST_ROOT_DIR"] ?? "")
               
               ${ROOT_DIR}/swiftlint --config ${ROOT_DIR}/.swiftlint.yml
               
               """,
-              name: "SwiftLint",
-              basedOnDependencyAnalysis: false
-            )
-          ],
-          dependencies: [
-            .project(target: "WineyKit", path: "../WineyKit"),
-            .external(name: "ComposableArchitecture"),
-            .external(name: "TCACoordinators"),
-            .external(name: "CombineExt"),
-          ])
+            name: "SwiftLint",
+            basedOnDependencyAnalysis: false
+          )
+        ],
+        dependencies: [
+          .project(target: "WineyKit", path: "../WineyKit"),
+          .project(target: "WineyNetwork", path: "../WineyNetwork"),
+          .external(name: "ComposableArchitecture"),
+          .external(name: "TCACoordinators"),
+          .external(name: "CombineExt"),
+          .external(name: "KakaoSDK")
+        ])
 ]
 
 let appproject = Project.init(name: "Winey",
-                           organizationName: "com.adultOfNineteen",
-                           targets: appTargets)
+                              organizationName: "com.adultOfNineteen",
+                              targets: appTargets)

--- a/Projects/WineyKit/Project.swift
+++ b/Projects/WineyKit/Project.swift
@@ -21,32 +21,35 @@ let infoPlist: [String: InfoPlist.Value] = [
 ]
 
 let wineyKitTargets: [Target] = [
-    .init(name: "WineyKit",
-          platform: .iOS,
-          product: .framework,
-          bundleId: "com.adultOfNineteen.wineyKit",
-          deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
-          infoPlist: .extendingDefault(with: infoPlist),
-          sources: ["Sources/**"],
-          resources: ["Resources/**"],
-          scripts: [
-            .pre(
-              script: """
+  .init(
+    name: "WineyKit",
+    platform: .iOS,
+    product: .framework,
+    bundleId: "com.adultOfNineteen.wineyKit",
+    deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
+    infoPlist: .extendingDefault(with: infoPlist),
+    sources: ["Sources/**"],
+    resources: ["Resources/**"],
+    scripts: [
+      .pre(
+        script: """
               ROOT_DIR=\(ProcessInfo.processInfo.environment["TUIST_ROOT_DIR"] ?? "")
               
               ${ROOT_DIR}/swiftlint --config ${ROOT_DIR}/.swiftlint.yml
               
               """,
-              name: "SwiftLint",
-              basedOnDependencyAnalysis: false
-            )
-          ],
-          dependencies: [
-            .project(target: "Utils", path: "../Utils")
-          ]
-         )
+        name: "SwiftLint",
+        basedOnDependencyAnalysis: false
+      )
+    ],
+    dependencies: [
+      .project(target: "Utils", path: "../Utils")
+    ]
+  )
 ]
 
-let wineyKitProject = Project.init(name: "WineyKit",
-                           organizationName: "com.adultOfNineteen",
-                           targets: wineyKitTargets)
+let wineyKitProject = Project.init(
+  name: "WineyKit",
+  organizationName: "com.adultOfNineteen",
+  targets: wineyKitTargets
+)

--- a/Projects/WineyNetwork/Project.swift
+++ b/Projects/WineyNetwork/Project.swift
@@ -1,0 +1,41 @@
+//
+//  Project.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 박혜운 on 2023/09/12.
+//
+
+import Foundation
+import ProjectDescription
+
+let wineyNetworkTargets: [Target] = [
+  .init(
+    name: "WineyNetwork",
+    platform: .iOS,
+    product: .framework,
+    bundleId: "com.adultOfNineteen.wineyNetwork",
+    deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
+    sources: ["Sources/**"],
+    scripts: [
+      .pre(
+        script: """
+              ROOT_DIR=\(ProcessInfo.processInfo.environment["TUIST_ROOT_DIR"] ?? "")
+              
+              ${ROOT_DIR}/swiftlint --config ${ROOT_DIR}/.swiftlint.yml
+              
+              """,
+        name: "SwiftLint",
+        basedOnDependencyAnalysis: false
+      )
+    ],
+    dependencies: [
+      .project(target: "Utils", path: "../Utils")
+    ]
+  )
+]
+
+let wineyNetworkProject = Project.init(
+  name: "WineyNetwork",
+  organizationName: "com.adultOfNineteen",
+  targets: wineyNetworkTargets
+)

--- a/Projects/WineyNetwork/Sources/BaseURL.swift
+++ b/Projects/WineyNetwork/Sources/BaseURL.swift
@@ -1,0 +1,13 @@
+//
+//  BaseURL.swift
+//  WineyNetwork
+//
+//  Created by 박혜운 on 2023/09/25.
+//  Copyright © 2023 com.adultOfNineteen. All rights reserved.
+//
+
+import Foundation
+
+public extension String {
+  static let baseURL = "http://winey-api-dev-env.eba-atefsiev.ap-northeast-2.elasticbeanstalk.com"
+}

--- a/Projects/WineyNetwork/Sources/Mock/MockDataProtocol.swift
+++ b/Projects/WineyNetwork/Sources/Mock/MockDataProtocol.swift
@@ -1,0 +1,27 @@
+//
+//  MockData.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/17.
+//
+
+import Foundation
+
+public protocol MockDataProtocol: JsonDataToDataProtocol {
+  var data: Data { get }
+  func data(fileName: String, extension: String) -> Data!
+}
+
+public protocol JsonDataToDataProtocol {
+  func data(fileName: String, extension: String) -> Data!
+}
+
+public extension JsonDataToDataProtocol {
+  func data(fileName: String, extension: String) -> Data! {
+    let fileLocation = Bundle.main.url(
+      forResource: fileName,
+      withExtension: `extension`
+    )!
+    return try? Data(contentsOf: fileLocation)
+  }
+}

--- a/Projects/WineyNetwork/Sources/Mock/MockURLProtocol.swift
+++ b/Projects/WineyNetwork/Sources/Mock/MockURLProtocol.swift
@@ -1,0 +1,45 @@
+//
+//  MockURLProtocol.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/16.
+//
+
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+  typealias RequestHandler = ((URLRequest) -> (Data?, HTTPURLResponse?, Error?))
+  static var requestHandler: RequestHandler?
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    return true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    return request
+  }
+
+  override func startLoading() {
+    guard let handler = MockURLProtocol.requestHandler else {
+      return
+    }
+
+    let (data, response, error) = handler(request)
+
+    if let error = error {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+
+    if let response = response {
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    if let data = data {
+      client?.urlProtocol(self, didLoad: data)
+    }
+
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() { }
+}

--- a/Projects/WineyNetwork/Sources/Mock/MockURLSessionProtocol.swift
+++ b/Projects/WineyNetwork/Sources/Mock/MockURLSessionProtocol.swift
@@ -1,0 +1,58 @@
+//
+//  MockURLSessionProtocol.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/16.
+//
+
+import Foundation
+
+public final class MockURLSession<MockDataType: MockDataProtocol>: URLSessionProtocol, JsonDataToDataProtocol {
+
+  // MARK: - Properties
+  
+  let urlSession: URLSession = {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
+    let urlSession = URLSession(configuration: configuration)
+    return urlSession
+  }()
+
+  let isFailRequest: Bool
+  let mockData: MockDataType?
+
+  let successStatusCode = 200
+  let failureStatusCode = 401
+  
+
+  // MARK: - Initialization
+  
+  public init(
+    mockData: MockDataType?
+  ) {
+    self.mockData = mockData
+    self.isFailRequest = (mockData == nil)
+  }
+
+  // MARK: - Public Methods
+  
+  public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    let successResponse = HTTPURLResponse(
+      url: request.url!,
+      statusCode: successStatusCode,
+      httpVersion: "2",
+      headerFields: nil)!
+    
+    let failureResponse = HTTPURLResponse(
+      url: request.url!,
+      statusCode: failureStatusCode,
+      httpVersion: "2",
+      headerFields: nil)!
+
+    let response = isFailRequest ? failureResponse : successResponse
+    
+    let data = isFailRequest ? data(fileName: "fail_data", extension: "json") : mockData?.data
+
+    return (data!, response)
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/EncodingType.swift
+++ b/Projects/WineyNetwork/Sources/Provider/EncodingType.swift
@@ -1,0 +1,38 @@
+//
+//  EncodingType.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/14.
+//
+
+import Foundation
+
+public enum EncodingType {
+  case jsonBody
+  case queryString
+}
+
+extension EncodingType {
+  func encode(_ urlRequest: URLRequest, with parameters: [String: Any]?) throws -> URLRequest {
+    var urlRequest = urlRequest
+    switch self {
+    case .jsonBody:
+      // JSON으로 본문 인코딩
+      if let parameters = parameters {
+        let jsonData = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        urlRequest.httpBody = jsonData
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      }
+    case .queryString:
+      // 쿼리 문자열로 인코딩
+      if let parameters = parameters {
+        let queryString = parameters.map { "\($0.key)=\($0.value)" }.joined(separator: "&")
+        if var urlComponents = URLComponents(url: urlRequest.url!, resolvingAgainstBaseURL: false) {
+          urlComponents.query = queryString
+          urlRequest.url = urlComponents.url
+        }
+      }
+    }
+    return urlRequest
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/EndPointType.swift
+++ b/Projects/WineyNetwork/Sources/Provider/EndPointType.swift
@@ -1,0 +1,75 @@
+//
+//  EndPointType.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/14.
+//
+
+import Foundation
+
+public protocol EndPointType {
+  var baseURL: String { get }
+  var path: String { get }
+  var method: HTTPMethod { get }
+  var task: HTTPTask { get }
+}
+
+public extension EndPointType {
+  /// Default is `["Content-Type": "application/json"]`
+  var headers: [String: String] {
+    return ["Content-Type": "application/json"]
+  }
+}
+
+public extension EndPointType {
+  
+  func asURLRequest() -> URLRequest? {
+    var urlComponents = URLComponents(string: self.baseURL)
+    urlComponents?.path += self.path
+    
+    guard let url = urlComponents?.url else {
+      return nil
+    }
+    
+    var urlRequest = URLRequest(url: url)
+    urlRequest.httpMethod = self.method.rawValue
+    
+    self.headers.forEach { key, value in
+      urlRequest
+        .setValue(
+          value,
+          forHTTPHeaderField: key
+        )
+    }
+    
+    if let accessToken = UserDefaults.standard.string(forKey: "accessToken") {
+      urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+    }
+    
+    return try? addParameter(to: urlRequest)
+  }
+  
+  
+  private func addParameter(to request: URLRequest) throws -> URLRequest {
+    var request = request
+    
+    switch task {
+    case .requestPlain:
+      break
+      
+    case let .requestJSONEncodable(parameters):
+      request.httpBody = try JSONEncoder().encode(parameters)
+      
+    case let .requestCustomJSONEncodable(parameters, encoder):
+      request.httpBody = try encoder.encode(parameters)
+      
+    case let .requestParameters(parameters, encoding):
+      request = try encoding.encode(request, with: parameters)
+      
+    case let .requestCompositeParameters(query, body):
+      request = try EncodingType.queryString.encode(request, with: query)
+      request = try EncodingType.jsonBody.encode(request, with: body)
+    }
+    return request
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/HTTPMethod.swift
+++ b/Projects/WineyNetwork/Sources/Provider/HTTPMethod.swift
@@ -1,0 +1,16 @@
+//
+//  HTTPMethod.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/14.
+//
+
+import Foundation
+
+public enum HTTPMethod: String {
+  case get = "GET"
+  case put = "PUT"
+  case post = "POST"
+  case patch = "PATCH"
+  case delete = "DELETE"
+}

--- a/Projects/WineyNetwork/Sources/Provider/HTTPTask.swift
+++ b/Projects/WineyNetwork/Sources/Provider/HTTPTask.swift
@@ -1,0 +1,21 @@
+//
+//  HTTPTask.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/14.
+//
+
+import Foundation
+
+public enum HTTPTask {
+  /// 추가 데이터 없는 요청.
+  case requestPlain
+  /// `Encodable` 타입으로 설정된 요청 바디.
+  case requestJSONEncodable(Encodable)
+  /// 사용자 정의 인코더와 함께 `Encodable` 타입으로 설정된 요청 바디.
+  case requestCustomJSONEncodable(Encodable, encoder: JSONEncoder)
+  /// GET의 쿼리 문자열 또는 POST의 바디에 값을 넣을 때 사용.
+  case requestParameters(parameters: [String: Any], encoding: EncodingType)
+  /// URL 파라미터와 함께 조합된 인코딩된 파라미터로 설정된 요청 바디.
+  case requestCompositeParameters(urlParameters: [String: Any], bodyParameters: [String: Any])
+}

--- a/Projects/WineyNetwork/Sources/Provider/Provider.swift
+++ b/Projects/WineyNetwork/Sources/Provider/Provider.swift
@@ -1,0 +1,68 @@
+//
+//  Provider.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/15.
+//
+
+import Foundation
+
+public struct Provider<Target: EndPointType> {
+  private let session: URLSessionProtocol
+  private let responseLogger = NetworkLogger()
+  
+  public init(session: URLSessionProtocol = Session.shared.session) {
+    self.session = session
+  }
+  
+  public func request<T: Decodable>(_ endPoint: EndPointType, type: T.Type) async -> Result<T, Error> {
+    return await requestObject(endPoint, type: type)
+  }
+}
+
+// MARK: Private Request Methods
+private extension Provider {
+  func requestObject<T: Decodable>(_ endPoint: EndPointType, type: T.Type) async -> Result<T, Error> {
+    
+    guard let request = endPoint.asURLRequest() else {
+      let error = ProviderError(
+        code: .failedDecode,
+        userInfo: ["endPoint" : endPoint]
+      )
+      return .failure(error)
+    }
+    
+    let task = try? await session.data(for: request)
+    
+    guard let (data, response) = task else {
+      let error = ProviderError(
+        code: .failedRequest,
+        userInfo: ["endPoint" : endPoint]
+      )
+      return .failure(error)
+    }
+    
+    guard let httpResponse = response as? HTTPURLResponse,
+          200..<300 ~= httpResponse.statusCode else {
+      let error = ProviderError(
+        code: .isNotSuccessful,
+        userInfo: ["endPoint" : endPoint],
+        task: (data, response)
+      )
+      return .failure(error)
+    }
+    
+    let targetModel = try? JSONDecoder().decode(ResponseDTO.ExistData<T>.self, from: data)
+    
+    guard let targetModel = targetModel, let model = targetModel.result else {
+      let error = ProviderError(
+        code: .failedDecode,
+        userInfo: ["endPoint" : endPoint],
+        task: (data, response)
+      )
+      return .failure(error)
+    }
+    
+    return .success(model)
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/ProviderError.swift
+++ b/Projects/WineyNetwork/Sources/Provider/ProviderError.swift
@@ -1,0 +1,47 @@
+//
+//  ProviderError.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/15.
+//
+
+import Foundation
+
+public struct ProviderError: Error {
+  public var code: Code
+  public var userInfo: [String: Any]?
+  public var errorBody: ResponseDTO.ErrorData?
+  
+  public enum Code: Int {
+    case failedRequest // 인터넷 불안정
+    case isNotSuccessful // 통신 결과 실패
+    case failedDecode // 프론트 잘못
+  }
+  
+  public init(
+    code: ProviderError.Code,
+    userInfo: [String: Any]? = nil,
+    task: (data: Data?, response: URLResponse?)? = nil
+  ) {
+    self.code = code
+    self.userInfo = userInfo
+    self.userInfo?["response"] = task?.response
+    
+    if let data = task?.data {
+      do {
+        self.errorBody = try JSONDecoder().decode(ResponseDTO.ErrorData.self, from: data)
+      } catch {
+        dump(error)
+      }
+    }
+  }
+}
+
+public extension Error {
+  func toProviderError() -> ProviderError? {
+    if let error = self as? ProviderError {
+      return error
+    }
+    return nil
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/ResponseDTO.swift
+++ b/Projects/WineyNetwork/Sources/Provider/ResponseDTO.swift
@@ -1,0 +1,40 @@
+//
+//  ResponseDTO.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/15.
+//
+
+import Foundation
+
+public enum ResponseDTO {
+  public struct ExistData<ResponseType: Decodable> {
+    public let isSuccess: Bool
+    public let code: String
+    public let message: String
+    public let result: ResponseType?
+    
+    enum CodingKeys: String, CodingKey {
+      case isSuccess
+      case code
+      case message
+      case result
+    }
+  }
+  
+  public struct ErrorData: Decodable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+  }
+}
+
+extension ResponseDTO.ExistData: Decodable where ResponseType: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    isSuccess = try container.decode(Bool.self, forKey: .isSuccess)
+    code = try container.decode(String.self, forKey: .code)
+    message = try container.decode(String.self, forKey: .message)
+    result = try container.decodeIfPresent(ResponseType.self, forKey: .result)
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/Session.swift
+++ b/Projects/WineyNetwork/Sources/Provider/Session.swift
@@ -1,0 +1,20 @@
+//
+//  Session.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/15.
+//
+
+import Foundation
+
+public final class Session {
+  public static let shared = Session()
+  
+  public let session: URLSession
+  
+  private init() {
+    let configuration = URLSessionConfiguration.default
+    let logger = NetworkLogger()
+    session = URLSession(configuration: configuration, delegate: logger, delegateQueue: nil)
+  }
+}

--- a/Projects/WineyNetwork/Sources/Provider/URLSessionProtocol.swift
+++ b/Projects/WineyNetwork/Sources/Provider/URLSessionProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  URLSessionProtocol.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/16.
+//
+
+import Foundation
+
+public protocol URLSessionProtocol {
+  func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol { }

--- a/Projects/WineyNetwork/Sources/Provider/VoidResponse.swift
+++ b/Projects/WineyNetwork/Sources/Provider/VoidResponse.swift
@@ -1,0 +1,10 @@
+//
+//  VoidResponse.swift
+//  Core
+//
+//  Created by 박혜운 on 2023/09/16.
+//
+
+import Foundation
+
+public struct VoidResponse: Decodable { }

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -12,6 +12,7 @@ let spm = SwiftPackageManagerDependencies([
   ),
   .remote(url: "https://github.com/pointfreeco/swift-composable-architecture.git", requirement: .range(from: "1.0.0", to: "2.0.0")),
   .remote(url: "https://github.com/johnpatrickmorgan/TCACoordinators.git", requirement: .exact("0.6.0")),
+  .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .branch("master"))
 ])
 
 let dependencies = Dependencies(


### PR DESCRIPTION
<img width="400" alt="image" src="https://github.com/AdultOfNineteen/WINEY-iOS/assets/81788774/8dca53f8-c1be-4ca6-a53a-16816f51c757">

# 요약 
* 네트워킹 모듈 생성 
* API 정의 후 Service (통신 객체) 만들어 사용

# 겪었던 문제사항 + 고민 공유 
> 내용이 깁니다! 공유 목적이 강하므로 부담없이 편히 읽어주세요! 
## 1️⃣ `Network.framwork` 모듈 생성 시 시뮬레이터 내부 프레임워크와 충돌 
해결 : WineyNetwork 로 모듈명 변경 
## 2️⃣ Network 방식 : async-await으로 인한 여러 문제
### 1️⃣ **NetworkLogger** (필수적인 로직에 관한 내용 아님)
아직 컴플리션 핸들러와 타이밍이 완벽 호환 되지 않는듯 합니다.  (추측)
네트워킹 내용을 콘솔창에 출력하기 위해 NetworkLogger를 작성하고 추가하였을 때 async-await로 작성하면 data를 전달 받는 시점을 명확히 전달 받기 어려웠습니다. (Delegate로 전달한 NetworkLogger)
```swift
public final class Session {
  public static let shared = Session()
  
  public let session: URLSession
  
  private init() {
    let configuration = URLSessionConfiguration.default
    let logger = NetworkLogger()
    session = URLSession(configuration: configuration, delegate: logger, delegateQueue: nil)
  }
}
```

```swift
//NetworkLogger.swift
// 응답 로깅
  func logResponse(response: URLResponse?, data: Data?) {
    debugPrint("🍷 Network Response Log 🍷")
    if let response = response as? HTTPURLResponse {
      debugPrint("  📩 [Status Code] : \(response.statusCode)") 
      if let data = data, let responseString = data.toPrettyPrintedString { // 🔥여기 출력 안됌 
        debugPrint("  📩 [Response] : \(responseString)")
      }
```
Provider 내부에 logResponse메서드를 호출하여 logger를 확인할 수 있지만 그를 의도한 것은(Provider에 직접 간섭) 아니기 때문에 보류하였습니다 
configure를 분리하여 dev 모드에서만 NetworkLogger가 작동하도록 하는 것이 목표⭐️ 입니다.
(혹시 API 통신 시 콘솔 창에 출력 되는 Logger가 유용하지 않고 불편하다면 말씀해 주세용!!)

### 2️⃣  ⭐️ **Provider** 로직  (실제 통신 로직)

```swift
private extension Provider {
  func requestObject<T: Decodable>(_ endPoint: EndPointType, type: T.Type) async -> Result<T, Error> {
```
에러를 throw 하지 않는 Result 함수로 `Provider`를 작성하였습니다.

이 과정에서 Error를 던지는 값을 풀어낼 때 try? 를 사용하여 Error를 반환하도록 작성하였습니다. 
```swift
let task = try? await session.data(for: request)
    
    guard let (data, response) = task else {
      let error = ProviderError(
        code: .failedRequest,
        userInfo: ["endPoint" : endPoint]
      )
      return .failure(error)
    }
```
Provider의 메서드가 반환하는 에러타입은 Error이나, Provider에서 보내는 Error는 모두 ProviderError 타입으로 전달 받는 화면에서 구체적인 Error 내역이 필요하다면 (아마 다양한 알림창) 필요 시 타입 변환하여 사용하면 됩니다! 

```swift
/// ProviderError.swift 내부 
public extension Error {
  func toProviderError() -> ProviderError? {
    if let error = self as? ProviderError {
      return error
    }
    return nil
  }
}
```
변환하는 메서드는 미리 만들어 두었습니다. 필요 시 아래와 같은 형태로 사용하면 됩니다! 
```swift
guard let providerError = error.toProviderError() else { return .none }
  switch providerError.code {
    case .....
  }
```
> 애초에 반환 타입을 ProviderError로 가져갈 생각도 하였으나... 흠 Error 타입을 지정하고 사용하는 데엔 찝찝함으로 (추후 너무 많은 Error 타입을 섞어 사용하게 될까) Error 타입으로 반환하도록 하였습니다. 

### 3️⃣ **MockProtocol 사용할 일 있나?**
이건 뒤에 작업하며 깨달은 일이지만, TCA가 상황 별 Dependency의 값 변환이 용이하도록 만들어 두어 굳이 Mock 데이터를 집어넣어 테스트할 일이 있을 지 잘 모르겠습니다. 
(당장은 테스트 코드가 없지만 서버 통신 없이 Mock 데이터 집어넣어 통신하더라도 Dependency 기본 구조로 해결 가능한 느낌...!)
잘 만들었다고 생각했지만....... 🥹
Network 모듈의 Mock 폴더는 사용하지 않을 수도 있습니다! (소리 소문없이 사라질 확률이 있습니다...) 

# 확인사항
연이어 보낼 PR에 작성해 두겠지만, 
AccessToken을 헤더에 넣어 보내는 로직이 검증되지 않았습니다. (작성해 두었으나 아직 사용해 보지 않았다는 뜻입니다!)
(해당 내용은 EndPointType.swift에 있습니다)
코드 상으로는 UserDefaults에 저장한 accessToken이 있다면 이를 헤더에 넣어 보내기 때문에 별다른 처리 없이 Provider를 생성하여 통신하시면 됩니다.
만약 통신시 에러가 난다면 연락 주십시오! 🔥

