### PR TITLE
Feature/main/win 111 홈api

### DIFF
--- a/Projects/App/Sources/Feature/Tab/Main/Coordinator/MainCoordinator/MainCoordinator.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Coordinator/MainCoordinator/MainCoordinator.swift
@@ -40,11 +40,13 @@ public struct MainCoordinator: Reducer {
         _,
         action: .main(
           .wineCardScroll(
-            .wineCard(id: _, action: ._navigateToCardDetail(_, wineData))
+            .wineCard(id: _, action: ._navigateToCardDetail(id, wineData))
           )
         )
       ):
-        state.routes.append(.push(.wineDetail(.init(wineCardData: wineData))))
+        state.routes.append(.push(
+          .wineDetail(.init(windId: id, wineCardData: wineData))
+        ))
         return .none
         
       case .routeAction(_, action: .wineDetail(.tappedBackButton)):

--- a/Projects/App/Sources/Feature/Tab/Main/Data/APIs/WineAPI.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Data/APIs/WineAPI.swift
@@ -1,0 +1,48 @@
+//
+//  WineAPI.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/12.
+//  Copyright © 2023 com.adultOfNineteen. All rights reserved.
+//
+
+import Foundation
+import WineyNetwork
+
+public enum WineAPI {
+  case todaysRecommendations
+  case wineDetailInfo(windId: String)
+}
+
+extension WineAPI: EndPointType {
+  public var baseURL: String {
+    return .baseURL
+  }
+  
+  public var path: String {
+    switch self {
+    case .todaysRecommendations:
+      return "/wines/recommend"
+    case let .wineDetailInfo(windId):
+      return "/wines/\(windId)"
+    }
+  }
+  
+  public var method: WineyNetwork.HTTPMethod {
+    switch self {
+    case .todaysRecommendations:
+      return .get
+    case .wineDetailInfo:
+      return .get
+    }
+  }
+  
+  public var task: WineyNetwork.HTTPTask {
+    switch self {
+    case .todaysRecommendations:
+      return .requestPlain
+    case .wineDetailInfo:
+      return .requestPlain
+    }
+  }
+}

--- a/Projects/App/Sources/Feature/Tab/Main/Data/DTO/RecommendWineDTO.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Data/DTO/RecommendWineDTO.swift
@@ -1,0 +1,18 @@
+//
+//  RecommendWineDTO.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/12.
+//  Copyright © 2023 com.adultOfNineteen. All rights reserved.
+//
+
+import Foundation
+
+public struct RecommendWineDTO: Codable {
+  let wineId: Int
+  let name: String
+  let country: String
+  let type: String
+  let varietal: [String]
+  let price: Int
+}

--- a/Projects/App/Sources/Feature/Tab/Main/Data/DTO/WineDTO.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Data/DTO/WineDTO.swift
@@ -1,0 +1,35 @@
+//
+//  WineDTO.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/12.
+//  Copyright © 2023 com.adultOfNineteen. All rights reserved.
+//
+
+import Foundation
+
+public struct WineDTO: Codable, Equatable {
+  public static func == (lhs: WineDTO, rhs: WineDTO) -> Bool { // 임시 
+    return true
+  }
+  
+  let wineId: Int
+  let type: String
+  let name: String
+  let country: String
+  let varietal: String
+  let sweetness: Int
+  let acidity: Int
+  let body: Int
+  let tannins: Int
+  let wineSummary: WineSummary
+}
+
+// MARK: - WineSummary
+public struct WineSummary: Codable {
+  let avgPrice: Double
+  let avgSweetness: Int
+  let avgAcidity: Int
+  let avgBody: Int
+  let avgTannins: Int
+}

--- a/Projects/App/Sources/Feature/Tab/Main/Services/WineService.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Services/WineService.swift
@@ -1,0 +1,119 @@
+//
+//  WineService.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/12.
+//  Copyright © 2023 com.adultOfNineteen. All rights reserved.
+//
+
+import Dependencies
+import Foundation
+import WineyNetwork
+
+public struct WineService {
+  public var todaysWines: () async -> Result<[WineCardData], Error>
+  public var winesDetail: (_ wineId: String) async -> Result<WineDTO, Error>
+}
+
+extension WineService {
+  static let live = {
+    return Self(
+      todaysWines: {
+        let dtoResult = await Provider<WineAPI>
+          .init()
+          .request(
+            WineAPI.todaysRecommendations,
+            type: [RecommendWineDTO].self
+          )
+        
+        switch dtoResult {
+        case let .success(dto):
+          return .success(
+            dto
+              .map {
+                WineCardData(
+                  id: $0.wineId,
+                  wineType: WineType.changeType(at: $0.type),
+                  wineName: $0.name,
+                  nationalAnthems: $0.country,
+                  varities: $0.varietal.first ?? "", // ... 요기는 잠시 생각
+                  purchasePrice: Double($0.price)
+                )
+              }
+          )
+        case let .failure(error):
+          return .failure(error)
+        }
+      },
+      winesDetail: { windId in
+        return await Provider<WineAPI>
+          .init()
+          .request(
+            WineAPI.wineDetailInfo(windId: windId),
+            type: WineDTO.self
+          )
+      }
+    )
+  }()
+  
+  static let mock = {
+    return Self(
+      todaysWines: {
+        return .success(
+          [ WineCardData(
+            id: 0,
+            wineType: .port,
+            wineName: "mock1",
+            nationalAnthems: "랄라라",
+            varities: "훔훔훔",
+            purchasePrice: 0.0
+          ),
+            WineCardData(
+              id: 1,
+              wineType: .rose,
+              wineName: "mock2",
+              nationalAnthems: "랄ㄹ라라",
+              varities: "용ㅇ요요",
+              purchasePrice: 0.0
+            )
+          ]
+        )
+      }, 
+      winesDetail: { wineId in
+        return .success(
+          WineDTO(
+            wineId: Int(wineId) ?? 0,
+            type: "PORT",
+            name: "mock1",
+            country: "mock1",
+            varietal: "랄라라",
+            sweetness: 3,
+            acidity: 2,
+            body: 3,
+            tannins: 4,
+            wineSummary: WineSummary(
+              avgPrice: 1.0,
+              avgSweetness: 2,
+              avgAcidity: 3,
+              avgBody: 2,
+              avgTannins: 1
+            )
+          )
+        )
+      }
+    )
+  }()
+//  static let unimplemented = Self(…)
+}
+
+extension WineService: DependencyKey {
+  public static var liveValue = Self.live
+  public static var previewValue = Self.mock
+}
+
+extension DependencyValues {
+  var wine: WineService {
+    get { self[WineService.self] }
+    set { self[WineService.self] = newValue }
+  }
+}

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/MainView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/MainView.swift
@@ -121,7 +121,7 @@ public struct MainView: View {
                 action: Main.Action.tipCard
               )
             ) { _ in
-                          
+              
               LazyVGrid(columns: columns, spacing: 20) {
                 ForEach(viewStore.tipCardState!.cardList.prefix(2)) { card in
                   Button(action: {
@@ -151,5 +151,18 @@ public struct MainView: View {
     .background(WineyKitAsset.mainBackground.swiftUIColor)
     .navigationViewStyle(StackNavigationViewStyle())
     .navigationBarHidden(true)
+  }
+}
+
+
+struct MainView_Previews: PreviewProvider {
+  static var previews: some View {
+    MainView(store: StoreOf<Main>(
+      initialState: .init(tooltipState: true),
+      reducer: { 
+        Main()
+          .dependency(\.wine, .mock)
+      })
+    )
   }
 }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineCardData.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineCardData.swift
@@ -172,4 +172,24 @@ public enum WineType: String {
       return  WineyAsset.Assets.etcIllust.swiftUIImage
     }
   }
+  
+  static func changeType(at type: String) -> Self {
+    let type = type.uppercased()
+    switch type {
+    case "RED":
+      return .red
+    case "WHITE":
+      return .white
+    case "ROSE":
+      return .rose
+    case "SPARKL":
+      return .sparkl
+    case "PORT":
+      return .port
+    case "ETC":
+      fallthrough
+    default:
+      return .etc
+    }
+  }
 }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineCardScroll.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineCardScroll.swift
@@ -17,42 +17,8 @@ public struct WineCardScroll: Reducer {
     var currentScrollIndex: Int
     var wineCards: IdentifiedArrayOf<WineCard.State>
     
-    public init() {
-      self.wineCards = [
-        WineCard.State(
-          index: 0,
-          wineCardData: WineCardData(
-            id: 0,
-            wineType: .etc,
-            wineName: "test1",
-            nationalAnthems: "test test test",
-            varities: "test", purchasePrice: 9.90
-          )
-        ),
-        
-        WineCard.State(
-          index: 1,
-          wineCardData: WineCardData(
-            id: 1,
-            wineType: .red,
-            wineName: "test2",
-            nationalAnthems: "test test test",
-            varities: "test", purchasePrice: 9.90
-          )
-        ),
-        
-        WineCard.State(
-          index: 2,
-          wineCardData: WineCardData(
-            id: 2,
-            wineType: .rose,
-            wineName: "test3",
-            nationalAnthems: "test test test",
-            varities: "test", purchasePrice: 9.90
-          )
-        ),
-      ]
-      
+    public init(wineCards: IdentifiedArrayOf<WineCard.State>) {
+      self.wineCards = wineCards
       self.previousScrollIndex = 0
       self.currentScrollIndex = 0
     }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineDetail/WineDetailGraph.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineDetail/WineDetailGraph.swift
@@ -107,6 +107,10 @@ struct WineDetailGraph: View {
 
 struct WineDetailGraph_Previews: PreviewProvider {
   static var previews: some View {
-    WineDetailGraph(category: "당도", originalStatistic: 3.0, peopleStatistic: 1.0)
+    WineDetailGraph(
+      category: "당도",
+      originalStatistic: 3.0,
+      peopleStatistic: 1.0
+    )
   }
 }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineDetail/WineDetailView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/WineDetail/WineDetailView.swift
@@ -78,12 +78,18 @@ public struct WineDetailView: View {
             .padding(.top, 36)
           
           // MARK: Wine Graph
-          WineDetailTabView()
-          
-            .frame(height: 450)
+          if let info = viewStore.windDetailData {
+            WineDetailTabView(detail: info)
+              .frame(height: 450)
+          } else {
+            ProgressView()
+          }
         }
         .padding(.top, 14)
         .padding(.horizontal, WineyGridRules.globalHorizontalPadding)
+      }
+      .onAppear {
+        viewStore.send(._viewWillAppear)
       }
     }
     .navigationBarHidden(true)
@@ -182,13 +188,51 @@ public struct WineInfoMiddle: View {
 }
 
 public struct WineDetailTabView: View {
+  private let detail: WineDTO
+  
+  init(detail: WineDTO) {
+    self.detail = detail
+  }
+  
   public var body: some View {
     TabView {
-      WineDetailInfoSum()
-      WineDetailGraph(category: "당도", originalStatistic: 1.0, peopleStatistic: 3.0)
-      WineDetailGraph(category: "산도", originalStatistic: 4.0, peopleStatistic: 2.0)
-      WineDetailGraph(category: "바디", originalStatistic: 3.0, peopleStatistic: 2.0)
-      WineDetailGraph(category: "탄닌", originalStatistic: 5.0, peopleStatistic: 4.0)
+      WineDetailInfoSum(detail: detail)
+      WineDetailGraph(
+        category: "당도",
+        originalStatistic: Double(detail.sweetness),
+        peopleStatistic: Double(
+          detail
+          .wineSummary
+          .avgSweetness
+        )
+      )
+      WineDetailGraph(
+        category: "산도",
+        originalStatistic: Double(detail.acidity),
+        peopleStatistic: Double(
+          detail
+          .wineSummary
+          .avgAcidity
+        )
+      )
+      WineDetailGraph(
+        category: "바디",
+        originalStatistic: Double(detail.body),
+        peopleStatistic: Double(
+          detail
+          .wineSummary
+          .avgBody
+        )
+      )
+      WineDetailGraph(
+        category: "탄닌",
+        originalStatistic: Double(detail.tannins),
+        peopleStatistic: Double(
+          detail
+          .wineSummary
+          .avgTannins
+        )
+      )
     }
     .tabViewStyle(PageTabViewStyle())
     .onAppear {
@@ -196,7 +240,7 @@ public struct WineDetailTabView: View {
     }
   }
   
-  func setupAppearance() {
+  private func setupAppearance() {
     UIPageControl.appearance()
       .currentPageIndicatorTintColor = WineyKitAsset.point1.color
     UIPageControl.appearance()
@@ -205,6 +249,12 @@ public struct WineDetailTabView: View {
 }
 
 public struct WineDetailInfoSum: View {
+  private let detail: WineDTO
+  
+  init(detail: WineDTO) {
+    self.detail = detail
+  }
+  
   public var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       HStack {
@@ -230,10 +280,42 @@ public struct WineDetailInfoSum: View {
       .padding(.bottom, 35)
       
       VStack(spacing: 0) {
-        WineInfoDetailGraph(peopleStatistic: 2.0, originalStatistic: 5.0, infoCategory: "당도")
-        WineInfoDetailGraph(peopleStatistic: 4.0, originalStatistic: 1.0, infoCategory: "산도")
-        WineInfoDetailGraph(peopleStatistic: 2.8, originalStatistic: 3.0, infoCategory: "바디")
-        WineInfoDetailGraph(peopleStatistic: 5.0, originalStatistic: 4.0, infoCategory: "탄닌")
+        WineInfoDetailGraph(
+          peopleStatistic: Double(
+            detail
+            .wineSummary
+            .avgSweetness
+          ),
+          originalStatistic: Double(detail.sweetness),
+          infoCategory: "당도"
+        )
+        WineInfoDetailGraph(
+          peopleStatistic: Double(
+            detail
+            .wineSummary
+            .avgAcidity
+          ),
+          originalStatistic: Double(detail.acidity),
+          infoCategory: "산도"
+        )
+        WineInfoDetailGraph(
+          peopleStatistic: Double(
+            detail
+            .wineSummary
+            .avgBody
+          ),
+          originalStatistic: Double(detail.body),
+          infoCategory: "바디"
+        )
+        WineInfoDetailGraph(
+          peopleStatistic: Double(
+            detail
+            .wineSummary
+            .avgTannins
+          ),
+          originalStatistic: Double(detail.tannins),
+          infoCategory: "탄닌"
+        )
       }
       .padding(.bottom, 22)
     }
@@ -244,9 +326,9 @@ public struct WineDetailInfoSum: View {
 
 // MARK: WINE INFO ILLUST
 public struct WineDetailIllust: View {
-  public let illustImage: Image
-  public let circleBorderColor: Color
-  public let secondaryColor: Color
+  private  let illustImage: Image
+  private  let circleBorderColor: Color
+  private  let secondaryColor: Color
   
   public init(
     illustImage: Image,
@@ -292,6 +374,7 @@ struct WineDetailView_Previews: PreviewProvider {
     WineDetailView(
       store: Store(
         initialState: WineDetail.State(
+          windId: 1,
           wineCardData: WineCardData(
             id: 1,
             wineType: .red,
@@ -301,6 +384,7 @@ struct WineDetailView_Previews: PreviewProvider {
             purchasePrice: 1.22)
         ), reducer: {
           WineDetail()
+            .dependency(\.wine, .mock)
         }
       )
     )

--- a/Projects/WineyNetwork/Sources/Provider/EndPointType.swift
+++ b/Projects/WineyNetwork/Sources/Provider/EndPointType.swift
@@ -43,7 +43,8 @@ public extension EndPointType {
     }
     
     if let accessToken = UserDefaults.standard.string(forKey: "accessToken") {
-      urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+//      urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+      urlRequest.setValue(accessToken, forHTTPHeaderField: "X-AUTH-TOKEN")
     }
     
     return try? addParameter(to: urlRequest)

--- a/Projects/WineyNetwork/Sources/Provider/NetworkLogger.swift
+++ b/Projects/WineyNetwork/Sources/Provider/NetworkLogger.swift
@@ -53,12 +53,12 @@ extension NetworkLogger: URLSessionTaskDelegate {
   }
   
   func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-    logResponse(response: task.response, data: receivedData)
+    // logResponse(response: task.response, data: receivedData)
     receivedData = nil
   }
   
   func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-    logResponse(response: task.response, data: receivedData)
+    // logResponse(response: task.response, data: receivedData) // 임시 삭제
     receivedData = nil
   }
 }

--- a/Projects/WineyNetwork/Sources/Provider/Provider.swift
+++ b/Projects/WineyNetwork/Sources/Provider/Provider.swift
@@ -42,8 +42,10 @@ private extension Provider {
       return .failure(error)
     }
     
+    NetworkLogger().logResponse(response: response, data: data) // 임시 
+    
     guard let httpResponse = response as? HTTPURLResponse,
-          200..<300 ~= httpResponse.statusCode else {
+    200..<300 ~= httpResponse.statusCode else {
       let error = ProviderError(
         code: .isNotSuccessful,
         userInfo: ["endPoint" : endPoint],


### PR DESCRIPTION
# 전달사항 
### .wineCardScroll 케이스에서의 상태 생성 
```swift 
// Main.swift 
case .wineCardScroll:
        state.wineCardListState = WineCardScroll.State.init()
        // state.wineCardListState = WineCardScroll.State.init() // ✔️🤔
        return .none
```
요기 .wineCardScroll에서 state값을 다시 생성해 주는 이유를 알 수 없어 우선 주석처리 해 두었습니다!   
혹 의도가 있었다면 수정해 주시고, (당장의 로직엔 문제 없음)  (특이점으로 보여서 삭제하지 않고 주석 처리만 해두었습니다)
의도가 잘 반영되었다면 주석 삭제해주시면 됩니다!   

### DetailView에서의 Data 모델  
와인의 디테일 정보를 요청시 해당 DTO 내부에는  
1. 기존의 Data 모델인 WineCardData 
2. 그래프에 필요한 숫자 값  
이 전부 포함되어 있습니다.  

따라서 해당 DTO로 DetailView 화면 전체를 보여줄 지, 아니면 DTO의 숫자 값만 사용하고 연결하고 이름, 품종과 같은 데이터는 이전 뷰에서 WineCardData를 받아와서 쓸 지 고민하였습니다.  
고민 결과 화면의 상단부가 로딩(딜레이) 없이 보여지는 것이 좋을 것 같아 상단 화면은 기존 데이터를 활용하는 쪽으로 만들어 두었습니다.  

# 질문사항
### IdentifiedArrayOf<> 사용법  
에 대한 이해가 부족하여 코드를 해치지 않는 선에서 API 연결 하였습니다.  
저도 사용 케이스가 궁금하였는데, 사용하신 이유에 대해 여쭙고 싶습니다!   