### PR TITLE
Feature/main/win 124 취향분석api

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -38,7 +38,7 @@ let appTargets: [Target] = [
   .init(name: "Winey",
         platform: .iOS,
         product: .app,
-        bundleId: "com.adultOfNineteen.app",
+        bundleId: "com.winey.app",
         deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
         infoPlist: .extendingDefault(with: infoPlist),
         sources: ["Sources/**"],
@@ -66,5 +66,5 @@ let appTargets: [Target] = [
 ]
 
 let appproject = Project.init(name: "Winey",
-                              organizationName: "com.adultOfNineteen",
+                              organizationName: "com.winey",
                               targets: appTargets)

--- a/Projects/App/Sources/Feature/Auth/Services/AuthService.swift
+++ b/Projects/App/Sources/Feature/Auth/Services/AuthService.swift
@@ -120,7 +120,16 @@ private struct SocialNetworking {
           }
         }
       } else {
-        continuation.resume(returning: nil)
+        Task {
+          UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+            if error != nil {
+              continuation.resume(returning: nil)
+            } else {
+              let accessToken = oauthToken?.accessToken
+              continuation.resume(returning: accessToken)
+            }
+          }
+        }
       }
     }
   }

--- a/Projects/App/Sources/Feature/Tab/Main/Coordinator/WineAnalysisCoordinator/WineAnalysisCoordinator.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Coordinator/WineAnalysisCoordinator/WineAnalysisCoordinator.swift
@@ -45,8 +45,8 @@ public struct WineAnalysisCoordinator: Reducer {
         state.routes.pop(2)
         return .none
         
-      case .routeAction(_, action: .loading(._onAppear)):
-        state.routes.push(.result(.init()))
+      case let .routeAction(_, action: .loading(._completeAnalysis(data))):
+        state.routes.push(.result(.init(data: data)))
         return .none
         
       default:

--- a/Projects/App/Sources/Feature/Tab/Main/Data/APIs/TastingNotesAPI.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Data/APIs/TastingNotesAPI.swift
@@ -1,0 +1,41 @@
+//
+//  TastingNotesAPI.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/18.
+//  Copyright © 2023 com.winey. All rights reserved.
+//
+
+import WineyNetwork
+
+public enum TastingNotesAPI {
+  case tasteAnalysis
+}
+
+extension TastingNotesAPI: EndPointType {
+  public var baseURL: String {
+    return .baseURL
+  }
+  
+  public var path: String {
+    switch self {
+    case .tasteAnalysis:
+      return "/tasting-notes/taste-analysis"
+    }
+  }
+  
+  public var method: HTTPMethod {
+    switch self {
+    case .tasteAnalysis:
+      return .get
+    }
+  }
+  
+  public var task: WineyNetwork.HTTPTask {
+    switch self {
+    case .tasteAnalysis:
+      return .requestPlain
+    }
+  }
+}
+

--- a/Projects/App/Sources/Feature/Tab/Main/Data/DTO/TasteAnalysisDTO.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Data/DTO/TasteAnalysisDTO.swift
@@ -1,0 +1,86 @@
+//
+//  TasteAnalysisDTO.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/18.
+//  Copyright © 2023 com.winey. All rights reserved.
+//
+
+import Foundation
+
+public struct TasteAnalysisDTO: Codable, Equatable {
+  /// 추천 국가
+  let recommendCountry: String?
+  /// 추천 품종
+  let recommendVarietal: String?
+  /// 추천 와인타입
+  let recommendWineType: String?
+  /// 총 마신 와인 병수
+  let totalWineCnt: Int
+  /// 재구매 의사가 있는 와인
+  let buyAgainCnt: Int
+  let topThreeTypes: [TopType]
+  let topThreeCountries: [TopCountry]
+  let topThreeVarieties: [TopVarietal]
+  let topSevenSmells: [TopSmell]
+  let taste: Taste
+  /// 평균 와인 가격
+  let avgPrice: Int
+  
+  enum CodingKeys: String, CodingKey {
+    case topThreeTypes = "top3Type"
+    case topThreeCountries = "top3Country"
+    case topThreeVarieties = "top3Varietal"
+    case topSevenSmells = "top7Smell"
+    case recommendCountry
+    case recommendVarietal
+    case recommendWineType
+    case totalWineCnt
+    case buyAgainCnt
+    case taste
+    case avgPrice
+  }
+  
+  public static func == (lhs: TasteAnalysisDTO, rhs: TasteAnalysisDTO) -> Bool {
+    return lhs.recommendCountry == rhs.recommendCountry &&
+    lhs.recommendVarietal == rhs.recommendVarietal &&
+    lhs.recommendWineType == rhs.recommendWineType &&
+    lhs.totalWineCnt == rhs.totalWineCnt &&
+    lhs.buyAgainCnt == rhs.buyAgainCnt &&
+    lhs.topThreeTypes == rhs.topThreeTypes &&
+    lhs.topThreeCountries == rhs.topThreeCountries &&
+    lhs.topThreeVarieties == rhs.topThreeVarieties &&
+    lhs.topSevenSmells == rhs.topSevenSmells &&
+    lhs.taste == rhs.taste &&
+    lhs.avgPrice == rhs.avgPrice
+  }
+}
+
+public struct TopType: Codable, Equatable {
+  let type: String
+  let percent: Int
+}
+
+public struct TopCountry: Codable, Equatable {
+  let country: String
+  let count: Int
+}
+
+public struct TopVarietal: Codable, Equatable {
+  let varietal: String
+  let percent: Int
+}
+
+public struct TopSmell: Codable, Equatable {
+  let smell: String
+  let percent: Int
+}
+
+public struct Taste: Codable, Equatable {
+  let sweetness: Double
+  let acidity: Double
+  let alcohol: Double
+  let body: Double
+  let tannin: Double
+  let finish: Double
+}

--- a/Projects/App/Sources/Feature/Tab/Main/Services/TasteAnalysisService.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Services/TasteAnalysisService.swift
@@ -1,0 +1,70 @@
+//
+//  TasteAnalysisService.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/18.
+//  Copyright © 2023 com.winey. All rights reserved.
+//
+
+import Dependencies
+import Foundation
+import WineyNetwork
+
+public struct TasteAnalysisService {
+  public var myTasteAnalysis: () async -> Result<TasteAnalysisDTO, Error>
+}
+
+extension TasteAnalysisService {
+  static let live = {
+    return Self(
+      myTasteAnalysis: {
+        return await Provider<TastingNotesAPI>
+          .init()
+          .request(
+            TastingNotesAPI.tasteAnalysis,
+            type: TasteAnalysisDTO.self
+          )
+      }
+    )
+  }()
+  
+  static let mock = {
+    return Self(
+      myTasteAnalysis: {
+        let result = TasteAnalysisDTO(
+          recommendCountry: nil,
+          recommendVarietal: nil,
+          recommendWineType: nil,
+          totalWineCnt: 0,
+          buyAgainCnt: 0,
+          topThreeTypes: [],
+          topThreeCountries: [],
+          topThreeVarieties: [],
+          topSevenSmells: [],
+          taste: Taste(
+            sweetness: 0,
+            acidity: 0,
+            alcohol: 0,
+            body: 0,
+            tannin: 0,
+            finish: 0
+          ),
+          avgPrice: 0
+        )
+        return .success(result)
+      }
+    )
+  }()
+}
+
+extension TasteAnalysisService: DependencyKey {
+  public static var liveValue = Self.live
+  public static var previewValue = Self.mock
+}
+
+extension DependencyValues {
+  var analysis: TasteAnalysisService {
+    get { self[TasteAnalysisService.self] }
+    set { self[TasteAnalysisService.self] = newValue }
+  }
+}

--- a/Projects/App/Sources/Feature/Tab/Main/Services/TastingNotesService.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/Services/TastingNotesService.swift
@@ -1,0 +1,9 @@
+//
+//  TastingNotesService.swift
+//  Winey
+//
+//  Created by 박혜운 on 2023/10/18.
+//  Copyright © 2023 com.winey. All rights reserved.
+//
+
+import Foundation

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisCarousel.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisCarousel.swift
@@ -13,21 +13,40 @@ import SwiftUI
 
 public struct WineAnalysisCarousel: Reducer {
   public struct State: Equatable {
-    
     let pageCount: Int = 6
     var pageIndex: Int = 0
     
-    var winePieChart = WineAnalysisPieChart.State.init()
-    var wineNation = WinePreferNation.State.init()
-    var wineCategory = WinePreferCategory.State.init()
-    var wineTaste = WinePreferTaste.State.init()
-    var wineSmell = WinePreferSmell.State.init()
-    var winePrice = WinePrice.State.init()
+    var winePieChart: WineAnalysisPieChart.State
+    var wineNation: WinePreferNation.State
+    var wineCategory: WinePreferCategory.State
+    var wineTaste: WinePreferTaste.State
+    var wineSmell: WinePreferSmell.State
+    var winePrice: WinePrice.State
     
-    public init() { }
+    public init(data: TasteAnalysisDTO) {
+      self.winePieChart = WineAnalysisPieChart.State.init(
+        wineDrink: data.totalWineCnt,
+        repurchase: data.buyAgainCnt, 
+        preferWineTypes: data.topThreeTypes
+      )
+      self.wineNation = WinePreferNation.State.init(
+        preferNationList: data.topThreeCountries
+      )
+      self.wineCategory = WinePreferCategory.State.init(
+        preferVarieties: data.topThreeVarieties
+      )
+      self.wineTaste = WinePreferTaste.State.init(
+        preferTastes: data.taste
+      )
+      self.wineSmell = WinePreferSmell.State.init()
+      self.winePrice = WinePrice.State.init(
+        price: data.avgPrice
+      )
+    }
   }
   
   public enum Action {
+    case _viewWillAppear
     // MARK: - User Action
     case dragGesture(DragGesture.Value)
     
@@ -47,6 +66,9 @@ public struct WineAnalysisCarousel: Reducer {
   public var body: some ReducerOf<Self> {
     Reduce<State, Action> { state, action in
       switch action {
+      case ._viewWillAppear:
+        return .none
+        
       case let .dragGesture(gesture):
         let dragThreshold: CGFloat = 50.0
         if gesture.translation.height > dragThreshold {

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisCarouselView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisCarouselView.swift
@@ -30,8 +30,8 @@ struct WineAnalysisCarouselView: View {
                   WineAnalysisPieChart()
                 }
               ))
-              .frame(width: geometry.size.width, height: geometry.size.height)
-              .id(0)
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            .id(0)
             
             WinePreferNationView(
               store: Store(
@@ -94,16 +94,41 @@ struct WineAnalysisCarouselView: View {
             }
         )
       }
+      .onAppear {
+        viewStore.send(._viewWillAppear)
+      }
     }
   }
 }
 
 
 public struct PreView: PreviewProvider {
+  static let data = TasteAnalysisDTO(
+    recommendCountry: "",
+    recommendVarietal: "",
+    recommendWineType: "",
+    totalWineCnt: 3,
+    buyAgainCnt: 7,
+    topThreeTypes: [],
+    topThreeCountries: [],
+    topThreeVarieties: [],
+    topSevenSmells: [],
+    taste: Taste(
+      sweetness: 0,
+      acidity: 0,
+      alcohol: 0,
+      body: 0,
+      tannin: 0,
+      finish: 0
+    ),
+    avgPrice: 30000
+  )
   public static var previews: some View {
     WineAnalysisCarouselView(
       store: Store(
-        initialState: WineAnalysisCarousel.State.init(),
+        initialState: WineAnalysisCarousel.State.init(
+          data: self.data
+        ),
         reducer: {
           WineAnalysisCarousel()
         }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisPieChart.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisPieChart.swift
@@ -13,10 +13,19 @@ import Foundation
 
 public struct WineAnalysisPieChart: Reducer {
   public struct State: Equatable {
-    let wineDrink: Int = 7
-    let repurchase: Int = 5
+    var wineDrink: Int
+    var repurchase: Int
+    var preferWineTypes: [TopType]
     
-    public init() { }
+    public init(
+      wineDrink: Int,
+      repurchase: Int,
+      preferWineTypes: [TopType]
+    ) {
+      self.wineDrink = wineDrink
+      self.repurchase = repurchase
+      self.preferWineTypes = preferWineTypes
+    }
   }
   
   public enum Action {
@@ -24,6 +33,7 @@ public struct WineAnalysisPieChart: Reducer {
     
     // MARK: - Inner Business Action
     case _onAppear
+    case _setPieChartData(TasteAnalysisDTO)
     
     // MARK: - Inner SetState Action
     
@@ -34,7 +44,9 @@ public struct WineAnalysisPieChart: Reducer {
     switch action {
     case ._onAppear:
       return .none
-    default:
+    case let ._setPieChartData(analysisData):
+      state.wineDrink = analysisData.totalWineCnt
+      state.repurchase = analysisData.buyAgainCnt
       return .none
     }
   }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisPieChartView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WineAnalysisPieChartView.swift
@@ -36,7 +36,6 @@ public struct WineAnalysisPieChartView: View {
             Text("\(viewStore.wineDrink)개의 와인을 마셨고,")
               .foregroundColor(WineyKitAsset.gray50.swiftUIColor)
           }
-          
           HStack(spacing: 0) {
             Text("\(viewStore.repurchase)개의 와인에 대해 재구매")
               .foregroundColor(WineyKitAsset.gray50.swiftUIColor)
@@ -48,8 +47,8 @@ public struct WineAnalysisPieChartView: View {
         .padding(.top, 22)
         
         WinePieChart(
-          values: [74, 20, 6],
-          names: ["레드", "화이트", "로제"]
+          values: viewStore.preferWineTypes.map{ $0.percent },
+          names: viewStore.preferWineTypes.map{ $0.type }
         )
         .padding(.top, 50)
         
@@ -92,7 +91,7 @@ public struct WinePieChart: View {
       GeometryReader { geometry in
         ZStack(alignment: .center) {
           
-          ForEach(0..<self.values.count){ idx in
+          ForEach(0..<self.values.count) { idx in
             PieSliceView(pieSliceData: self.slices[idx], rank: idx)
               .scaleEffect(idx == 0 ? 1.1 : 1.0)
           }
@@ -245,10 +244,15 @@ public struct WineAnalysisPieChartView_Previews: PreviewProvider {
   public static var previews: some View {
     WineAnalysisPieChartView(
       store: Store(
-        initialState: WineAnalysisPieChart.State.init(),
+        initialState: WineAnalysisPieChart.State.init(
+          wineDrink: 3,
+          repurchase: 3, 
+          preferWineTypes: []
+        ),
         reducer: {
           WineAnalysisPieChart()
-        })
+        }
+      )
     )
   }
 }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferCategory.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferCategory.swift
@@ -14,13 +14,24 @@ public struct WinePreferCategory: Reducer {
   public struct State: Equatable {
     
     let title = "선호 품종"
-    let wines: [WineRankData] = [
-      WineRankData(id: 1, rank: .rank1, wineName: "프리미티보", percentage: 74),
-      WineRankData(id: 2, rank: .rank2, wineName: "메들로", percentage: 12),
-      WineRankData(id: 3, rank: .rank3, wineName: "까르베네 소비뇽", percentage: 6)
-    ]
+    let wines: [WineRankData] 
     
-    public init() { }
+//    [
+//      WineRankData(id: 1, rank: .rank1, wineName: "프리미티보", percentage: 74),
+//      WineRankData(id: 2, rank: .rank2, wineName: "메들로", percentage: 12),
+//      WineRankData(id: 3, rank: .rank3, wineName: "까르베네 소비뇽", percentage: 6)
+//    ]
+    
+    public init(preferVarieties: [TopVarietal]) {
+      wines = (preferVarieties.indices).map {
+        WineRankData(
+          id: $0,
+          rank: WineRank(rawValue: $0 + 1) ?? .rank1,
+          wineName: preferVarieties[$0].varietal,
+          percentage: preferVarieties[$0].percent
+        )
+      }
+    }
   }
   
   public enum Action {

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferNation.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferNation.swift
@@ -20,13 +20,20 @@ public struct WinePreferNation: Reducer {
   
   public struct State: Equatable {
     let titleName = "선호 국가"
-    let winePreferNationList: IdentifiedArrayOf<WinePreferNationData> = [
-      WinePreferNationData(id: 1, nationName: "이탈리아", count: 3),
-      WinePreferNationData(id: 2, nationName: "미국", count: 1),
-      WinePreferNationData(id: 3, nationName: "칠레", count: 1)
-    ]
+    let winePreferNationList: IdentifiedArrayOf<WinePreferNationData>
     
-    public init() { }
+    public init(preferNationList: [TopCountry]) {
+      winePreferNationList = IdentifiedArrayOf(
+        uniqueElements:
+          (preferNationList.indices).map {
+            WinePreferNationData(
+              id: $0,
+              nationName: preferNationList[$0].country,
+              count: preferNationList[$0].count
+            )
+          }
+      )
+    }
   }
   
   public enum Action {
@@ -39,7 +46,7 @@ public struct WinePreferNation: Reducer {
     
     // MARK: - Child Action
   }
-
+  
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case ._onAppear:

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferNationView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferNationView.swift
@@ -126,8 +126,15 @@ public struct WineAnalysisTitle: View {
 
 public struct WinePreferNationView_Previews: PreviewProvider {
   public static var previews: some View {
-    WinePreferNationView(store: Store(initialState: WinePreferNation.State.init(), reducer: {
-      WinePreferNation()
-    }))
+    WinePreferNationView(
+      store: Store(
+        initialState:
+          WinePreferNation.State.init(
+            preferNationList: []),
+        reducer: {
+          WinePreferNation()
+        }
+      )
+    )
   }
 }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferSmell.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferSmell.swift
@@ -15,7 +15,6 @@ public struct WinePreferSmell: Reducer {
     
     let title = "가격대"
     let secondTitle = "평균 구매가"
-    let average: Int = 70580
     var opacity = 0.0
     
     public init() { }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferTaste.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePreferTaste.swift
@@ -16,14 +16,21 @@ public struct WinePreferTaste: Reducer {
     let title = "선호하는 맛"
     var animation = 0.0
     
-    var sweet: CGFloat = 7
-    var remain: CGFloat = 2
-    var alcohol: CGFloat = 7
-    var tannin: CGFloat = 2
-    var wineBody: CGFloat = 6
-    var acid: CGFloat = 3
+    var sweet: CGFloat
+    var remain: CGFloat
+    var alcohol: CGFloat
+    var tannin: CGFloat
+    var wineBody: CGFloat
+    var acid: CGFloat
     
-    public init() { }
+    public init(preferTastes taste: Taste) {
+      self.sweet = taste.sweetness
+      self.remain = taste.finish
+      self.alcohol = taste.alcohol
+      self.tannin = taste.tannin
+      self.wineBody = taste.body
+      self.acid = taste.acidity
+    }
   }
   
   public enum Action {

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePrice.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePrice.swift
@@ -14,10 +14,12 @@ public struct WinePrice: Reducer {
   public struct State: Equatable {
     let title = "가격대"
     let secondTitle = "평균 구매가"
-    let average: Int = 70580
+    let average: Int
     var opacity = 0.0
     
-    public init() { }
+    public init(price: Int) {
+      self.average = price
+    }
   }
   
   public enum Action {

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePriceView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/AnalysisResult/WinePriceView.swift
@@ -1,4 +1,3 @@
-
 //
 //  WinePriceView.swift
 //  Winey
@@ -77,7 +76,9 @@ struct WinePriceView_Previews: PreviewProvider {
   static var previews: some View {
     WinePriceView(
       store: Store(
-        initialState: WinePrice.State.init(),
+        initialState: WinePrice.State.init(
+          price: 30000
+        ),
         reducer: {
           WinePrice()
         })

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisLoading.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisLoading.swift
@@ -27,18 +27,31 @@ public struct WineAnalysisLoading: Reducer {
     
     // MARK: - Inner Business Action
     case _onAppear
+    case _completeAnalysis(TasteAnalysisDTO)
+    case _failureNetworking(Error) // 후에 경고창 처리
     
     // MARK: - Inner SetState Action
     
     // MARK: - Child Action
   }
+  
+  @Dependency(\.analysis) var analysisService
 
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .tappedBackButton:
       return .none
     case ._onAppear:
-      return .none
+      return .run { send in
+        let result = await analysisService.myTasteAnalysis()
+        switch result {
+        case let .success(data):
+          await send(._completeAnalysis(data))
+        case let .failure(error):
+          await send(._failureNetworking(error))
+        }
+      }
+      
     default:
       return .none
     }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisLoadingView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisLoadingView.swift
@@ -68,7 +68,9 @@ public struct WineAnalysisLoadingView_Previews: PreviewProvider {
   public static var previews: some View {
     WineAnalysisLoadingView(
       store: Store(
-        initialState: WineAnalysisLoading.State.init(userName: "성경"),
+        initialState: WineAnalysisLoading.State.init(
+          userName: "성경"
+        ),
         reducer: {
           WineAnalysisLoading()
         }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisResult.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisResult.swift
@@ -14,15 +14,17 @@ import Foundation
 
 public struct WineAnalysisResult: Reducer {
   public struct State: Equatable {
-    let wineRecommend: String = "이탈리아의 프리미티보 품종으로 만든 레드 와인"
-    let wineCount: Int = 7
-    let wineRepurchase: Int = 5
+    let wineRecommend: String // "이탈리아의 프리미티보 품종으로 만든 레드 와인"
+    let wineCount: Int
+    let wineRepurchase: Int
     
-    var carouselList = WineAnalysisCarousel.State.init()
+    var carouselList: WineAnalysisCarousel.State
     
-    public init(
-    ) {
-      
+    public init(data: TasteAnalysisDTO) {
+      self.wineRecommend = data.recommendWineType ?? ""
+      self.wineCount = data.totalWineCnt
+      self.wineRepurchase = data.buyAgainCnt
+      self.carouselList = WineAnalysisCarousel.State.init(data: data)
     }
   }
   

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisResultView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Analysis/WineAnalysisResultView.swift
@@ -73,11 +73,36 @@ public struct WineAnalysisResultView: View {
   }
 }
 
-public struct WineAnalysisResultView_Previews: PreviewProvider {
+public struct WineAnalysisResultView_Previews:
+  PreviewProvider {
+  static let data = TasteAnalysisDTO(
+    recommendCountry: "",
+    recommendVarietal: "",
+    recommendWineType: "",
+    totalWineCnt: 3,
+    buyAgainCnt: 7,
+    topThreeTypes: [],
+    topThreeCountries: [],
+    topThreeVarieties: [],
+    topSevenSmells: [],
+    taste: Taste(
+      sweetness: 0,
+      acidity: 0,
+      alcohol: 0,
+      body: 0,
+      tannin: 0,
+      finish: 0
+    ),
+    avgPrice: 30000
+  )
+  
   public static var previews: some View {
     WineAnalysisResultView(
       store: Store(
-        initialState: WineAnalysisResult.State.init(),
+        initialState: WineAnalysisResult.State
+          .init(
+            data: data
+          ),
           reducer: {
             WineAnalysisResult()
           }

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Main.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/Main.swift
@@ -88,7 +88,6 @@ public struct Main: Reducer {
         return .none
         
       case .wineCardScroll:
-        // state.wineCardListState = WineCardScroll.State.init() // ✔️🤔
         return .none
         
       case .userScroll:

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/MainView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/MainView.swift
@@ -158,8 +158,10 @@ public struct MainView: View {
 struct MainView_Previews: PreviewProvider {
   static var previews: some View {
     MainView(store: StoreOf<Main>(
-      initialState: .init(tooltipState: true),
-      reducer: { 
+      initialState: .init(
+        tooltipState: true
+      ),
+      reducer: {
         Main()
           .dependency(\.wine, .mock)
       })

--- a/Projects/App/Sources/Feature/Tab/Main/View/MainScene/TipCard/TipCardView.swift
+++ b/Projects/App/Sources/Feature/Tab/Main/View/MainScene/TipCard/TipCardView.swift
@@ -58,4 +58,3 @@ public struct TipCardView_Previews: PreviewProvider {
     }))
   }
 }
-

--- a/Projects/Utils/Project.swift
+++ b/Projects/Utils/Project.swift
@@ -7,7 +7,7 @@ let utilsTargets: [Target] = [
     .init(name: "Utils",
           platform: .iOS,
           product: .framework,
-          bundleId: "com.adultOfNineteen.utils",
+          bundleId: "com.winey.utils",
           deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
           sources: ["Sources/**"],
           scripts: [
@@ -28,5 +28,5 @@ let utilsTargets: [Target] = [
 ]
 
 let utilsProject = Project.init(name: "Utils",
-                           organizationName: "com.adultOfNineteen",
+                           organizationName: "com.winey",
                            targets: utilsTargets)

--- a/Projects/WineyKit/Project.swift
+++ b/Projects/WineyKit/Project.swift
@@ -25,7 +25,7 @@ let wineyKitTargets: [Target] = [
     name: "WineyKit",
     platform: .iOS,
     product: .framework,
-    bundleId: "com.adultOfNineteen.wineyKit",
+    bundleId: "com.winey.wineyKit",
     deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
     infoPlist: .extendingDefault(with: infoPlist),
     sources: ["Sources/**"],
@@ -50,6 +50,6 @@ let wineyKitTargets: [Target] = [
 
 let wineyKitProject = Project.init(
   name: "WineyKit",
-  organizationName: "com.adultOfNineteen",
+  organizationName: "com.winey",
   targets: wineyKitTargets
 )

--- a/Projects/WineyNetwork/Project.swift
+++ b/Projects/WineyNetwork/Project.swift
@@ -13,7 +13,7 @@ let wineyNetworkTargets: [Target] = [
     name: "WineyNetwork",
     platform: .iOS,
     product: .framework,
-    bundleId: "com.adultOfNineteen.wineyNetwork",
+    bundleId: "com.winey.wineyNetwork",
     deploymentTarget: .iOS(targetVersion: "16.0", devices: [.iphone]),
     sources: ["Sources/**"],
     scripts: [
@@ -36,6 +36,6 @@ let wineyNetworkTargets: [Target] = [
 
 let wineyNetworkProject = Project.init(
   name: "WineyNetwork",
-  organizationName: "com.adultOfNineteen",
+  organizationName: "com.winey",
   targets: wineyNetworkTargets
 )

--- a/Projects/WineyNetwork/Sources/Provider/NetworkLogger.swift
+++ b/Projects/WineyNetwork/Sources/Provider/NetworkLogger.swift
@@ -77,14 +77,14 @@ fileprivate extension Data {
     guard let object = try? JSONSerialization.jsonObject(
       with: self, options: []
     ),
-          let data = try? JSONSerialization.data(
-            withJSONObject: object,
-            options: [.prettyPrinted]
-          ),
-          let prettyPrintedString = NSString(
-            data: data,
-            encoding: String.Encoding.utf8.rawValue
-          ) else {
+    let data = try? JSONSerialization.data(
+      withJSONObject: object,
+      options: [.prettyPrinted]
+    ),
+    let prettyPrintedString = NSString(
+      data: data,
+      encoding: String.Encoding.utf8.rawValue
+    ) else {
       return nil
     }
     return prettyPrintedString as String


### PR DESCRIPTION
# 전달사항 🦦
* 기존 뷰 구성을 이루는 데이터 타입을 변경시키지 않고,  
생성자 내부에서 DTO 형태에서 원하는 값만 연결해주는 방식으로 구현하였습니다  

* 실기기 미연결 시 KAKAO 로그인 불가한 문제를 개선하고자 KAKAO 웹 로그인 경로를 추가해 두었습니다  
  * (시뮬레이터 상에서 로그인 가능)
 
* Domain 명 수정하였습니다, Tuist clean, fetch 이후 사용하시면 됩니다 🙆‍♀️

# 질문사항  
현재는 AppCoordinator로 부터 분석화면이 연결 및 실행되던데, 이유가 있을까요?  
MainCoordinator에 연결된다고 생각했었어서요!  

질문 있다면 언제든 환영입니당 !  

