### PR TITLE
[Feat] #92 Amplitude 설정

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "amplitude-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-Swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "df08b88cca1035d36b54efa01ce0d2b4ad43419d"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "e2ca17ac735bcbc48b13062484541702ef45153d",
+        "version" : "1.0.3"
+      }
+    },
+    {
       "identity" : "appauth-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openid/AppAuth-iOS.git",

--- a/Projects/App/Sources/App/Root/AppDelegate.swift
+++ b/Projects/App/Sources/App/Root/AppDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 com.adultOfNineteen. All rights reserved.
 //
 
+import AmplitudeSwift
 import Foundation
 import GoogleSignIn
 import KakaoSDKAuth
@@ -40,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     
+    AmplitudeProvider.initProvider(apiKey: APIKeys.amplitudeApiKey)
     KakaoSDK.initSDK(appKey: APIKeys.kakaoAppKey)
     
     self.window = UIWindow(frame: UIScreen.main.bounds)

--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -9,6 +9,11 @@
 import AmplitudeSwift
 import Foundation
 
+/// Ampltiude Event에 필요한 case를 정의합니다.
+public enum AmplitudeEvent: String {
+  case tappedAnalysis
+}
+
 final class AmplitudeProvider: ObservableObject {
   
   /// AmplitudeProvider의 싱글톤 객체. AmplitudeProvider를 사용하기 전 우선적으로 초기화되어야 합니다.
@@ -35,7 +40,7 @@ final class AmplitudeProvider: ObservableObject {
   }
   
   /// 특정 이벤트를 호출합니다.
-  func track(eventName: String) {
-    self.amplitude?.track(eventType: eventName)
+  func track(event: AmplitudeEvent) {
+    self.amplitude?.track(eventType: event.rawValue)
   }
 }

--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -1,0 +1,41 @@
+//
+//  AmplitudeProvider.swift
+//  Winey
+//
+//  Created by 정도현 on 7/14/24.
+//  Copyright © 2024 Winey. All rights reserved.
+//
+
+import AmplitudeSwift
+import Foundation
+
+final class AmplitudeProvider: ObservableObject {
+  
+  /// AmplitudeProvider의 싱글톤 객체. AmplitudeProvider를 사용하기 전 우선적으로 초기화되어야 합니다.
+  static let shared = AmplitudeProvider()
+  
+  private var amplitude: Amplitude?
+  
+  private init() {
+    amplitude = nil
+  }
+  
+  /// Amplitude 싱글톤 객체를 초기화 합니다. (Amplitude APIKey 사용)
+  public static func initProvider(apiKey: String) {
+    AmplitudeProvider.shared.initialize(apiKey: apiKey)
+  }
+  
+  private func initialize(apiKey: String) {
+    amplitude = Amplitude(
+      configuration: Configuration(
+        apiKey: apiKey,
+        defaultTracking: .ALL
+      )
+    )
+  }
+  
+  /// 특정 이벤트를 호출합니다.
+  func track(eventName: String) {
+    self.amplitude?.track(eventType: eventName)
+  }
+}


### PR DESCRIPTION
### 연관 이슈 🧚
> #92 Amplitude / 초기 설정

## 요약
> Amplitude SDK 연동 및 초기 설정을 진행하였습니다.


## 작업 내용
### 1. AmplitudeProvider (Singleton class)

Appdelegate.Swift에서 KakaoSDK와 함께 초기화 되도록 하였으며, 해당 시점부터 Ampltiude에서 추적이 진행됩니다.
(파일 경로: Projects/App/Project/Sources/App/Utils/AmplitudeProvider.Swift)
~~~Swift
final class AmplitudeProvider: ObservableObject {
  
  /// AmplitudeProvider의 싱글톤 객체. AmplitudeProvider를 사용하기 전 우선적으로 초기화되어야 합니다.
  static let shared = AmplitudeProvider()
  
  private var amplitude: Amplitude?
  
  private init() {
    amplitude = nil
  }
  
  /// Amplitude 싱글톤 객체를 초기화 합니다. (Amplitude APIKey 사용)
  public static func initProvider(apiKey: String) {
    AmplitudeProvider.shared.initialize(apiKey: apiKey)
  }
  
  private func initialize(apiKey: String) {
    amplitude = Amplitude(
      configuration: Configuration(
        apiKey: apiKey,
        defaultTracking: .ALL
      )
    )
  }
}
~~~
<br>

### 2. Amplitude이벤트 호출
추후 이벤트 정의 후 적용할 이벤트들을 사용할 때 아래의 메소드를 사용해서 amplitude에 전송해주면 됩니다.

~~~Swift
/// Ampltiude Event에 필요한 case를 정의합니다.
public enum AmplitudeEvent: String {
  case tappedAnalysis
}

/// 특정 이벤트를 호출합니다.
func track(event: AmplitudeEvent) {
  self.amplitude?.track(eventType: event.rawValue)
}
~~~

### 작업 스크린샷 (선택)

## 공유사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br>

---
격려의 한 마디 (선택) <br>
외마디 비명 (선택)
