### PR TITLE
[Feat] #92 Amplitude - Home Event 연결

### DIFF
--- a/Projects/App/Sources/App/Coordinator/AppCoordinator.swift
+++ b/Projects/App/Sources/App/Coordinator/AppCoordinator.swift
@@ -136,7 +136,8 @@ public struct AppCoordinator: Reducer {
         state.routes.append(.push(.wineTip(.tipList)))
         return .none
         
-      case let .routeAction(_, action: .tabBar(.main(.routeAction(_, action: .main(.wineTip(.tappedTipCard(url: url))))))):
+      case let .routeAction(_, action: .tabBar(.main(.routeAction(_, action: .main(.wineTip(._moveDetailTipCard(url: url))))))):
+        
         state.routes.append(.push(.wineTip(.tipDetail(url: url))))
         return .none
         

--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -11,7 +11,12 @@ import Foundation
 
 /// Ampltiude Event에 필요한 case를 정의합니다.
 public enum AmplitudeEvent: String {
-  case tappedAnalysis
+  
+  // Home Event
+  case HOME_ENTER
+  case WINE_DETAIL_CLICK
+  case ANALYZE_BUTTON_CLICK
+  case TIP_POST_CLICK
 }
 
 final class AmplitudeProvider: ObservableObject {

--- a/Projects/App/Sources/Main/Reducer/Main.swift
+++ b/Projects/App/Sources/Main/Reducer/Main.swift
@@ -91,6 +91,7 @@ public struct Main: Reducer {
         return .none
         
       case .tappedAnalysisButton:
+        AmplitudeProvider.shared.track(event: .ANALYZE_BUTTON_CLICK)
         return .send(._navigateToAnalysis)
         
       case .tappedTipArrow:

--- a/Projects/App/Sources/Main/Reducer/Main.swift
+++ b/Projects/App/Sources/Main/Reducer/Main.swift
@@ -51,6 +51,8 @@ public struct Main: Reducer {
     Reduce<State, Action> { state, action in
       switch action {
       case ._viewWillAppear:
+        AmplitudeProvider.shared.track(event: .HOME_ENTER)
+        
         return .run(operation: { send in
           switch await wineService.todaysWines() {
           case let .success(data):

--- a/Projects/App/Sources/RecommendWine/Reducer/WineCard.swift
+++ b/Projects/App/Sources/RecommendWine/Reducer/WineCard.swift
@@ -37,6 +37,7 @@ public struct WineCard: Reducer {
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .wineCardTapped:
+      AmplitudeProvider.shared.track(event: .WINE_DETAIL_CLICK)
       return .send(._navigateToCardDetail(state.recommendWineData.id, state.recommendWineData))
       
     case ._navigateToCardDetail:

--- a/Projects/App/Sources/WineTip/Coordinator/WineTipCoordinator.swift
+++ b/Projects/App/Sources/WineTip/Coordinator/WineTipCoordinator.swift
@@ -46,7 +46,7 @@ public struct WineTipCoordinator: Reducer {
     Reduce<State, Action> { state, action in
       switch action {
       
-      case let .routeAction(_, action: .tipCardList(.tappedTipCard(url: url))):
+      case let .routeAction(_, action: .tipCardList(._moveDetailTipCard(url: url))):
         state.routes.append(.push(.tipCardDetail(.init(url: url))))
         return .none
         

--- a/Projects/App/Sources/WineTip/Reducer/TipCard.swift
+++ b/Projects/App/Sources/WineTip/Reducer/TipCard.swift
@@ -35,6 +35,7 @@ public struct TipCard: Reducer {
     
     // MARK: - Inner Business Action
     case _viewWillAppear
+    case _moveDetailTipCard(url: String)
     case _fetchNextTipCardPage
     case _appendNextTipCardData(WineTipDTO)
     
@@ -65,6 +66,10 @@ public struct TipCard: Reducer {
             await send(._failureSocialNetworking(error))
           }
         })
+        
+      case let .tappedTipCard(url):
+        AmplitudeProvider.shared.track(event: .TIP_POST_CLICK)
+        return .send(._moveDetailTipCard(url: url))
         
       case let ._setTipCards(data: data):
         state.tipCards = data


### PR DESCRIPTION
### 연관 이슈 🧚
> #92 Amplitude / Home Event 연결


## 요약
> Amplitude Home Event 정의 및 연결


## 작업 내용
### 1. Home Event 연결

|Event Name|Description|
|--|--|
|`HOME_ENTER`|홈 진입|
|`WINE_DETAIL_CLICK`|와인 상세 페이지 클릭|
|`ANALYZE_BUTTON_CLICK`|"분석하기 버튼" 클릭|
|`TIP_POST_CLICK`|"오늘의 와인 팁 게시물" 클릭|

### 작업 스크린샷 (선택)

## 공유사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<br>

---
격려의 한 마디 (선택) <br>
외마디 비명 (선택)
