### PR TITLE
[Feat] #92 Amplitude - Mypage Event 연결

### DIFF
--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -21,6 +21,7 @@ public enum AmplitudeEvent: String {
   // MyPage Event
   case MYPAGE_ENTER
   case WINEY_BADGE_CLICK
+  case YOUNG_BADGE_CLICK
 }
 
 final class AmplitudeProvider: ObservableObject {

--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -20,6 +20,7 @@ public enum AmplitudeEvent: String {
   
   // MyPage Event
   case MYPAGE_ENTER
+  case WINEY_BADGE_CLICK
 }
 
 final class AmplitudeProvider: ObservableObject {

--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -17,6 +17,9 @@ public enum AmplitudeEvent: String {
   case WINE_DETAIL_CLICK
   case ANALYZE_BUTTON_CLICK
   case TIP_POST_CLICK
+  
+  // MyPage Event
+  case MYPAGE_ENTER
 }
 
 final class AmplitudeProvider: ObservableObject {

--- a/Projects/App/Sources/UserInfo/Reducer/UserBadge.swift
+++ b/Projects/App/Sources/UserInfo/Reducer/UserBadge.swift
@@ -71,6 +71,10 @@ public struct UserBadge: Reducer {
       let userId = state.userId
       let badgeId = badge.badgeId
       
+      if badge.name == "YOUNG" {
+        AmplitudeProvider.shared.track(event: .YOUNG_BADGE_CLICK)
+      }
+      
       return .run { send in
         switch await badgeService.badgeDetail(userId, badgeId) {
         case let .success(data):

--- a/Projects/App/Sources/UserInfo/Reducer/UserInfo.swift
+++ b/Projects/App/Sources/UserInfo/Reducer/UserInfo.swift
@@ -62,6 +62,8 @@ public struct UserInfo: Reducer {
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case ._viewWillAppear:
+      AmplitudeProvider.shared.track(event: .MYPAGE_ENTER)
+      
       return .run { send in
         await send(._getUserInfo)
         await send(._getNickName)

--- a/Projects/App/Sources/UserInfo/Reducer/UserInfo.swift
+++ b/Projects/App/Sources/UserInfo/Reducer/UserInfo.swift
@@ -170,6 +170,7 @@ public struct UserInfo: Reducer {
       
     case .userBadgeButtonTapped(let userId):
       if let userId = userId {
+        AmplitudeProvider.shared.track(event: .WINEY_BADGE_CLICK)
         return .send(._moveToBadgeTap(userId))
       } else {
         return .none  // TODO: 에러 분기처리


### PR DESCRIPTION
### 연관 이슈 🧚
> #92 Amplitude / Mypage Event 연결


## 요약
> Amplitude Mypage Event 정의 및 연결


## 작업 내용
### 1. Mypage Event 연결

|Event Name|Description|
|--|--|
|`MYPAGE_ENTER`|마이페이지 진입|
|`WINEY_BADGE_CLICK`|"WINEY BADGE" 클릭|
|`YOUNG_BADGE_CLICK`|"YOUNG BADGE" 클릭|

### 작업 스크린샷 (선택)

## 공유사항 (선택)
> 메인 탭바 - 모든 탭바 로드

현재 4개의 탭바에서 어느 한 탭을 접속하던, 모든 4개의 탭바에서 onAppear가 작동하는 상태입니다. 추후 모듈화 작업을 통해 이 부분을 수정하며, `MYPAGE_ENTER` 로직도 수정하면 좋을 것 같아요!!!


<br>

---
격려의 한 마디 (선택) <br>
외마디 비명 (선택)
