### PR TITLE
[Feat] #92 Amplitude - 탭 시작점 Event 수정 및 연결

### DIFF
--- a/Projects/App/Sources/TabBar/TabBar.swift
+++ b/Projects/App/Sources/TabBar/TabBar.swift
@@ -51,7 +51,7 @@ public struct TabBar: Reducer {
     case _loadingTab(TabBarItem)
     
     // MARK: - Inner SetState Action
-    case _mapStreamConnect(TabBarItem)
+    case _mapStreamConnect
     
     // MARK: - Child Action
     case main(MainCoordinator.Action)
@@ -73,15 +73,15 @@ public struct TabBar: Reducer {
       case let .tabSelected(tab):
         if tab == .map {
           return .concatenate([
-            .send(._mapStreamConnect(tab)),
+            .send(._mapStreamConnect),
             .send(._loadingTab(tab))
           ])
         } else {
           return .send(._loadingTab(tab))
         }
-        
-      case let ._mapStreamConnect(tab):
-        return .send(.map(.routeAction(0, action: .map(._tappedMapTabBarItem(tab == .map)))))
+      
+      case ._mapStreamConnect:
+        return .send(.map(.routeAction(0, action: .map(._tappedMapTabBarItem))))
         
       case .main(.routeAction(_, action: .main(._viewWillAppear))):
         return .send(._setTabHiddenStatus(false))

--- a/Projects/App/Sources/TabBar/TabBarInfoView.swift
+++ b/Projects/App/Sources/TabBar/TabBarInfoView.swift
@@ -19,31 +19,25 @@ struct TabBarInfoView: View {
     .first { $0.isKeyWindow }
   
   var body: some View {
-    GeometryReader { geo in
-      VStack {
-        Spacer()
+    VStack {
+      Spacer()
+      
+      HStack(spacing: 0) {
         
-        HStack {
-          Spacer().frame(width: 45)
-          singleTab(tab: TabBarItem.main)
+        ForEach(TabBarItem.allCases, id: \.rawValue) { tab in
+          singleTab(tab: tab)
           
-          Spacer()
-          singleTab(tab: TabBarItem.map)
-          
-          Spacer()
-          singleTab(tab: TabBarItem.note)
-          
-          Spacer()
-          singleTab(tab: TabBarItem.userInfo)
-          
-          Spacer().frame(width: 45)
+          if tab.rawValue != 3 {
+            Spacer()
+          }
         }
-        .padding(.vertical, 12)
-        .background(WineyKitAsset.gray900.swiftUIColor)
-        .cornerRadius(14, corners: [.topLeft, .topRight])
       }
-      .ignoresSafeArea(edges: [.bottom])
+      .padding(.horizontal, 45)
+      .padding(.vertical, 12)
+      .background(WineyKitAsset.gray900.swiftUIColor)
+      .cornerRadius(14, corners: [.topLeft, .topRight])
     }
+    .ignoresSafeArea(edges: [.bottom])
   }
 }
 

--- a/Projects/App/Sources/App/Coordinator/AppCoordinator.swift
+++ b/Projects/App/Sources/App/Coordinator/AppCoordinator.swift
@@ -68,27 +68,7 @@ public struct AppCoordinator: Reducer {
           .root(
             .tabBar(
               .init(
-                main: .init(),
-                map: .init(),
-                note: .init(),
-                userInfo: .init(),
-                isTabHidden: false
-              )
-            ),
-            embedInNavigationView: true
-          )
-        ]
-        return .none
-        
-      case .routeAction(_, action: .splash(._moveToHome)):
-        state.routes = [
-          .root(
-            .tabBar(
-              .init(
-                main: .init(),
-                map: .init(),
-                note: .init(),
-                userInfo: .init(),
+                selectedTab: .main,
                 isTabHidden: false
               )
             ),
@@ -105,15 +85,41 @@ public struct AppCoordinator: Reducer {
         ]
         return .none
         
+      case .routeAction(_, action: .splash(._moveToHome)):
+        state.routes = [
+          .root(
+            .tabBar(
+              .init(
+                selectedTab: .main,
+                isTabHidden: false
+              )
+            ),
+            embedInNavigationView: true
+          )
+        ]
+        return .none
+        
       case .routeAction(_, action: .auth(.routeAction(_, action: .setWelcomeSignUp(.tappedStartButton)))):
         state.routes = [
           .root(
             .tabBar(
               .init(
-                main: .init(),
-                map: .init(),
-                note: .init(),
-                userInfo: .init(),
+                selectedTab: .main,
+                isTabHidden: false
+              )
+            ),
+            embedInNavigationView: true
+          )
+        ]
+        return .none
+      
+      /// 유저가 Tab 클릭 시 해당 Tab으로 이동 및 해당 Tab만 로드되도록 설정
+      case let .routeAction(_, action: .tabBar(._loadingTab(tab))):
+        state.routes = [
+          .root(
+            .tabBar(
+              .init(
+                selectedTab: tab,
                 isTabHidden: false
               )
             ),

--- a/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
+++ b/Projects/App/Sources/App/Utils/AmplitudeProvider.swift
@@ -18,6 +18,9 @@ public enum AmplitudeEvent: String {
   case ANALYZE_BUTTON_CLICK
   case TIP_POST_CLICK
   
+  // Map event
+  case MAP_ENTER
+  
   // Note Event
   case NOTE_CREATE_BUTTON_CLICK
   case WINE_SELECT_BUTTON_CLICK

--- a/Projects/App/Sources/Map/Reducer/Map.swift
+++ b/Projects/App/Sources/Map/Reducer/Map.swift
@@ -40,6 +40,7 @@ public struct Map: Reducer {
     case tappedReloadCurrentMap
     
     // MARK: - Inner Business Action
+    case _viewWillAppear
     case _checkLocation
     case _userLocationIsEnabled(Bool) // 미사용
     case _getShopInfo
@@ -67,6 +68,10 @@ public struct Map: Reducer {
     
     Reduce { state, action in
       switch action {
+      case ._viewWillAppear:
+        AmplitudeProvider.shared.track(event: .MAP_ENTER)
+        return .none
+        
       case let ._tappedMapTabBarItem(isTappedMapTabBarItem):
         guard !state.tappedOpenFirst else {
           state.tappedOpenFirst = false

--- a/Projects/App/Sources/Map/Reducer/Map.swift
+++ b/Projects/App/Sources/Map/Reducer/Map.swift
@@ -53,7 +53,7 @@ public struct Map: Reducer {
     // MARK: - Inner SetState Action
     case _tabBarHidden
     case _tabBarOpen
-    case _tappedMapTabBarItem(Bool)
+    case _tappedMapTabBarItem
   }
   
   @Dependency(\.mainQueue) var mainQueue
@@ -72,12 +72,12 @@ public struct Map: Reducer {
         AmplitudeProvider.shared.track(event: .MAP_ENTER)
         return .none
         
-      case let ._tappedMapTabBarItem(isTappedMapTabBarItem):
+      case ._tappedMapTabBarItem:
         guard !state.tappedOpenFirst else {
           state.tappedOpenFirst = false
           return .send(._checkLocation)
         }
-        guard isTappedMapTabBarItem else { return .none }
+        
         return .cancel(id: CancelID.mapMarker)
         
       case ._checkLocation:

--- a/Projects/App/Sources/Map/View/MapView.swift
+++ b/Projects/App/Sources/Map/View/MapView.swift
@@ -111,6 +111,9 @@ public struct MapView: View {
       }
       .padding(.bottom, 169)
     }
+    .onAppear {
+      viewStore.send(._viewWillAppear)
+    }
     .ignoresSafeArea()
     .shopBottomSheet(
       height: viewStore.binding(


### PR DESCRIPTION
### 연관 이슈 🧚
> #92 Amplitude / 탭 시작점 Event 수정 및 연결


## 요약
> 기존 각 탭의 시작점인 뷰를 진입할때 호출하던 로직을 수정하였습니다. (탭 클릭시 클릭된 탭만 로딩되도록 수정)


## 작업 내용
### 1. 추가된 Event
|Event Name|Description|
|--|--|
|`MAP_ENTER`|지도 진입|

### 2. TabBar 코드 수정
<strong> 1️⃣ TabBar Initializer 수정 </strong>
~~~ Swift
// TabBar.swift

public init(
      /// Tab을 클릭했을 때 해당 Tab만 로딩되도록 설정.
      selectedTab: TabBarItem,
      isTabHidden: Bool
    ) {
      self.isTabHidden = isTabHidden
      self.selectedTab = selectedTab
      
      switch selectedTab {
      case .main:
        self.main = .init()
      case .map:
        self.map = .init()
      case .note:
        self.note = .init()
      case .userInfo:
        self.userInfo = .init()
      }
    }
~~~
기존 AppCoordinator에서 .init()을 통해 주입시켜주던 각탭의 상태를 `selectedTab`을 인자로 받아 해당 Tab만 State가 로딩되도록 수정하였습니다. 
해당 초기화 로직이 호출되는 AppCoordinator 예시는 다음 코드와 같습니다.
~~~ Swift
// AppCoordinator.swift

case let .routeAction(_, action: .tabBar(._loadingTab(tab))):
        state.routes = [
          .root(
            .tabBar(
              .init(
                selectedTab: tab,
                isTabHidden: false
              )
            ),
            embedInNavigationView: true
          )
        ]
        return .none
~~~

---

<strong> 2️⃣ TabBar _mapStreamConnect action 리팩토링 </strong><br>
기존 _mapStreamConnect 처리를 연관값 Bool 타입을 통해 `._tappedMapTabBarItem(tab == .map)`로 처리되던 부분을 이전 분기인 `.tabSelected`에서 map을 따로 필터링해서 이벤트를 전달하는 방식으로 변경하였습니다.
따라서 어떤 상황에서든 tab == .map인 경우만 action이 Trigger되도록 하였으며, 이로인해 불필요해진 연관값은 제거하였습니다.

``` Swift
// TabBar.swift

case ._mapStreamConnect:
        return .send(.map(.routeAction(0, action: .map(._tappedMapTabBarItem))))
```

``` Swift
// Map.swift

case ._tappedMapTabBarItem:
        guard !state.tappedOpenFirst else {
          state.tappedOpenFirst = false
          return .send(._checkLocation)
        }
        
        return .cancel(id: CancelID.mapMarker)
```

---

<strong> 3️⃣ TabBar 뷰 리팩토링 </strong><br>
기존 ForEach()문 내부의 불필요한 코드를 CaseIterable을 통해 제거하였습니다.

---

### 작업 스크린샷 (선택)

## 공유사항 (선택)
> 위의 TabBar 코드 수정 부분의 2️⃣ 번 과정에서 혹시 잘못 수정된 부분이 있다면 체크 부탁드립니다!!! 🔥🔥


<br>

---
격려의 한 마디 (선택) 
MC3 end? WINEY LET'S GO~! 😎 <br>

외마디 비명 (선택)
